### PR TITLE
Fix test-flags that should be test_flags

### DIFF
--- a/ci/scenarios/test.yml
+++ b/ci/scenarios/test.yml
@@ -7,14 +7,14 @@ jobs:
   parameters:
     job_name: cargo_test_min_ver
     job_displayName: Test min supported version
-    test-flags: 
+    test_flags: 
       nocapture: true
     rust: ${{ parameters['min_rust_supported'] }}
 
 # Cargo test last stable version of rust
 - template: ../jobs/cargo-test.yaml
   parameters:
-    test-flags:
+    test_flags:
       nocapture: true
 
 - template: ../jobs/cargo-test.yaml
@@ -23,5 +23,5 @@ jobs:
     job_name: cargo_test_nightly
     job_displayName: Cargo test (nightly)
     job_continueOnError: true
-    test-flags: 
+    test_flags: 
       nocapture: true


### PR DESCRIPTION
This had me scratching my head for quite a while when I added options here.

If you look in ci/jobs/cargo-test.yaml, it is `test_flags` and not `test-flags`.