### PR TITLE
Updated macOS image to macOS-10.15

### DIFF
--- a/ci/jobs/cargo-test.yaml
+++ b/ci/jobs/cargo-test.yaml
@@ -10,7 +10,7 @@ parameters:
       Linux:
         vmImage: ubuntu-16.04
       MacOS:
-        vmImage: macOS-10.13
+        vmImage: macOS-10.15
       Windows:
         vmImage: vs2017-win2016
   # global parameters

--- a/ci/scenarios/builds.yml
+++ b/ci/scenarios/builds.yml
@@ -49,7 +49,7 @@ jobs:
         job_name: ${{ build.name }}
         job_displayName: "target ${{ build.target }}"
         job_pool:
-          vmImage: macOS-10.13
+          vmImage: macOS-10.15
         release: ${{ parameters['release'] }} 
         target: "${{ build.target }}"
         job_pre-steps: ${{ build['pre-steps'] }}


### PR DESCRIPTION
Using `macOS-10.13` is causing warnings in Azure DevOps as it will be removed soon.

See https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

Updated to `macOS-10.15` as this is the newest image available.